### PR TITLE
Abort exunit if a suite fails.

### DIFF
--- a/src/rebar_exunit.erl
+++ b/src/rebar_exunit.erl
@@ -78,4 +78,8 @@ perform_exunit(_Config, Files) ->
       _ -> ok
     end,
     [ 'Elixir.Code':require_file(list_to_binary(File)) || File <- Files ],
-    'Elixir.ExUnit':run().
+    Result = 'Elixir.ExUnit':run(),
+    case maps:get(failures, Result) of
+      0 -> ok;
+      F -> rebar_utils:abort("~p or more tests failed.~n", [F])
+    end.

--- a/src/rebar_exunit.erl
+++ b/src/rebar_exunit.erl
@@ -81,5 +81,5 @@ perform_exunit(_Config, Files) ->
     Result = 'Elixir.ExUnit':run(),
     case maps:get(failures, Result) of
       0 -> ok;
-      F -> rebar_utils:abort("~p or more tests failed.~n", [F])
+      F -> rebar_utils:abort("~p tests failed.~n", [F])
     end.


### PR DESCRIPTION
This is to return an error exit code for the 'rebar exunit' command, even if running in subdirs.


------------------------------
The plugin used to run all tests but do nothing with the result, so the exit status for the 'exunit' command would always be 0 (OK), which doesn't play well with CI tools.