### PR TITLE
Add src_dirs local option to rebar_exunit plugin.

### DIFF
--- a/src/rebar_elixir_plugin.app.src
+++ b/src/rebar_elixir_plugin.app.src
@@ -1,7 +1,7 @@
 {application, rebar_elixir_plugin,
  [
   {description, "rebar plugin for compiling elixir source code"},
-  {vsn, git},
+  {vsn, "0.1.0"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
This is needed for Record.extract/2 to find a .hrl file in the current project.
